### PR TITLE
Get game name when playing on Steam Deck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.2.0] - 2025-04-23
+
+### Added
+
+- Parse game names out of activity details reported by "Discord Status" Decky plugin on Steam Deck
+
+## [0.1.0] - 2024-01-18
+
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 - Parse game names out of activity details reported by "Discord Status" Decky plugin on Steam Deck
 
-## [0.1.0] - 2024-01-18
+## [0.1.0] - 2025-01-18
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ services:
       - TOKEN=discord-secret
     restart: on-failure
 ```
+
+## Changelog
+
+0.2.0: Can parse game out of Steam Deck activity

--- a/README.md
+++ b/README.md
@@ -21,6 +21,3 @@ services:
     restart: on-failure
 ```
 
-## Changelog
-
-0.2.0: Can parse game out of Steam Deck activity

--- a/oblivionis/bot.py
+++ b/oblivionis/bot.py
@@ -17,7 +17,7 @@ bot = commands.Bot(command_prefix=commands.when_mentioned, intents=intents)
 
 def game_from_activity(activity) -> str:
     if activity.name == "Steam Deck":
-        return activity.details.replace("Playing ", "")
+        return activity.details.removeprefix("Playing ")
     return activity.name
 
 @bot.event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oblivionis"
-version = "0.1.0"
+version = "0.2.0"
 description = "Discord bot for tracking gameplay time"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
The Decky plugin "Discord Status" reports `activty.name` as "Steam Deck", and puts the actual game title in `activity.details`. So in this PR I have changed it so its checking to see if the activity name is Steam Deck, and if so it attempts to extract the actual game name out of the details, stripping out "Playing ". Otherwise it just returns `activity.name` as previously.

(Down the line this could be extended to support emulators and stuff that also reports actual game title in its details)
