### PR TITLE
Store platform in Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [X.X.X] - 202X-XX-XX
+
+### Added
+
+- Storing platform from Discord's `activity.platform` field (or a special case for Steam Deck). Defaults to `pc` if not specified. Existing activity will have `pc` set as their platform.
+
 ## [0.2.0] - 2025-04-23
 
 ### Added

--- a/oblivionis/bot.py
+++ b/oblivionis/bot.py
@@ -33,7 +33,7 @@ def application_id_from_activity(activity) -> str:
     """Returns application_id if present. Fallsback to name if not."""
     if hasattr(activity, "application_id"):
         return activity.application_id
-    # ps5 games seem to be missing application_id
+    # When playing on PS5, application_id seems to be missing
     logger.warning("Activity %s does not have application_id, using name instead...", activity.name)
     return activity.name
 
@@ -61,10 +61,12 @@ def get_stored_activity(member, activity) -> dict | None:
 def platform_from_activity(activity) -> str:
     """Get the platform from the activity. Fallbacks to pc."""
     if activity.name == "Steam Deck":
+        # Decky Discord Status plugin will sometimes say game name is "Steam Deck", 
+        # and put actual game name in description (see game_from_activity())
         return "steamdeck"
     platform = activity.platform or "pc"
     if platform == "desktop": 
-        # some games say "desktop" apparently
+        # Some games say "desktop", lets just lump it together with "pc"
         platform = "pc"
     return platform
 

--- a/oblivionis/storage.py
+++ b/oblivionis/storage.py
@@ -43,3 +43,5 @@ class Activity(BaseModel):
 def connect_db():
     db.connect()
     db.create_tables([User, Game, Activity])
+    # add platform column to activity table if it does not exist
+    db.execute_sql("ALTER TABLE activity ADD COLUMN IF NOT EXISTS platform VARCHAR DEFAULT 'pc'")

--- a/oblivionis/storage.py
+++ b/oblivionis/storage.py
@@ -37,6 +37,7 @@ class Activity(BaseModel):
     user = ForeignKeyField(User)
     game = ForeignKeyField(Game)
     seconds = IntegerField()
+    platform = CharField(default="pc")
 
 
 def connect_db():


### PR DESCRIPTION
- Added a `platform` CharField for Activity. Defaults to `pc` (existing activity will get that value)
    - There's probably a prettier way to add the column to existing databases. I tried using [Playhouse Migrations](https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#schema-migrations), which worked, once. If you restarted the app, it would complain about the column already existing, so just using a raw SQL statement like this was much simpler, albeit ugly.
- If `activity.platform` is present in the Discord activity that is used (eg `ps5`) 
    - If not available, `pc` will be used
    - Steam Deck (Decky Discord Activity) has a special case
- Added a `application_id_from_activity()` function, because PS5 activity seems to be missing `application_id`. Not sure if using `activity.name` is a good call.

--------------------

```
2025-09-21 11:03:11 INFO:oblivionis.bot:Oblivionis is ready
2025-09-21 11:03:18 WARNING:oblivionis.bot:Activity The Last of Us™ Remastered does not have application_id, using name instead...
2025-09-21 11:03:18 INFO:oblivionis.bot:Member djs has started playing The Last of Us™ Remastered (ps5)
2025-09-21 11:03:39 INFO:oblivionis.bot:Member djs has stopped playing The Last of Us™ Remastered (ps5) after 22 seconds
2025-09-21 11:17:43 INFO:oblivionis.bot:Member djs has started playing Balatro (pc)
2025-09-21 11:17:53 INFO:oblivionis.bot:Member djs has stopped playing Balatro (pc) after 8 seconds
```

```
oblivionis=# select * from activity;
 id |         timestamp          |      user_id      | game_id | seconds | platform 
----+----------------------------+-------------------+---------+---------+----------
  1 | 2025-09-21 09:01:37.659122 | 84733730387673088 |       2 |      13 | pc
  2 | 2025-09-21 09:03:39.969318 | 84733730387673088 |       5 |      22 | ps5
  3 | 2025-09-21 09:17:53.200166 | 84733730387673088 |       2 |       8 | pc
  ```